### PR TITLE
Fixed fadein keyframe

### DIFF
--- a/assets/autoMemberlist.css
+++ b/assets/autoMemberlist.css
@@ -29,6 +29,7 @@
 }
 
 @keyframes fadein {
+	from {opacity: 0}
 	to {opacity: 1}
 }
 


### PR DESCRIPTION
Without the from attribute, default value "1" is set for opacity and the animation wont work