### PR TITLE
Cleaner Delete Message Menu

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -1,7 +1,7 @@
 .theme-dark .user-settings-account:after,
 .theme-light .user-settings-account:after {
   color: var(--accent); font-weight: bold;
-  content: "Theme version: 1.0.2.34";
+  content: "Theme version: 1.0.3.56";
 }
 /* GLOBAL */
 :root {
@@ -1297,6 +1297,15 @@
   background-color: #606060;
   color: #fff;
 }
+
+.form .btn-default, .form .btn-default:hover {
+    background-color: var(--dark-secondary);
+}
+
+.form .btn.red {
+    background-color: var(--dark-secondary);
+}
+
 /* END: Form */
 
 /* Modal */


### PR DESCRIPTION
Just cleaned the remove message menu a bit.
I also liked the idea that the background faded in when hovering so I kept it there.
Also because I'm lazy.

![mediumwarpedamethystsunbird-size_restricted](https://cloud.githubusercontent.com/assets/22428156/24828356/5e3b3c92-1c5b-11e7-981c-6dd6c08e787b.gif)
