### PR TITLE
Add new defDarkColors plugin to use default dark theme colors and notifications

### DIFF
--- a/Plugins.md
+++ b/Plugins.md
@@ -38,6 +38,12 @@ You can also change the background image in NSFW channels. Enjoy!
 @import "https://rawgit.com/AlexFlipnote/Discord_Theme/master/assets/wideGuilds.css";
 ```
 
+### Use Default Discord Dark Theme Colors and Notifications (Community made)
+[Click here for preview](https://i.alexflipnote.xyz/.png)
+```css
+@import "https://rawgit.com/AlexFlipnote/Discord_Theme/master/assets/defDarkColors.css";
+```
+
 ### Auto-hide Member list in Guilds
 [Click here for preview](https://i.alexflipnote.xyz/cc78b7.gif)
 ```css

--- a/assets/defDarkColors.css
+++ b/assets/defDarkColors.css
@@ -1,0 +1,47 @@
+/* Plugin Made by Discord User @ .JS#2125
+   also on Github @ https://github.com/wwdc17 */
+/* PM .JS for support */
+
+:root {
+  /*--<var>: <value>*/
+  --rednotif: #FF0000;
+  --notif: #7A78BD;
+  --accent: #7A78BD;
+  --dark-primary: #2e3136;
+  --dark-secondary: #36393e;
+  --dark-highlight: #2e3136;
+  --dark-highlight-guildlist: #1e2124;
+  --light-primary: #ddd;
+  --light-secondary: #ecf0f1;
+  --light-highlight: #9E9E9E;
+--nsfw-image: url("https://i.alexflipnote.xyz/c2472b.png");
+}
+
+/* Server Section */
+/* BOTH */
+.guilds-wrapper { background: var(--dark-highlight-guildlist); }
+/* End Server Section */
+
+/* Notifications */
+.badge {
+  background-color: var(--rednotif);
+}
+.new-messages-indicator.new-messages-indicator-mention {
+  background-color: var(--rednotif);
+}
+.guilds-wrapper .guilds .guild.selected:before,
+.guilds-wrapper .guilds .guild.selected.unread:before,
+.guilds-wrapper .guilds .guild.unread:before {
+  z-index: 100;
+  background: var(--notif);
+  height: 12px;
+  width: 12px;
+  margin-top: 0px;
+  margin-top: 35px!important;
+  margin-left: -30px!important;
+  border-radius: 50%;
+  border: 0.5px solid black;
+}
+/* End Notifications */
+
+/* THANKS FOR USING DEFDARKCOLORS.CSS */


### PR DESCRIPTION
defDarkColors.css:
• Changes almost all dark theme :root variables to original discord dark theme colors
• Adds --rednotif var for red notification badge used for mentions
• Adds --discord-highlight-guildlist for guild list color
• Change a lot of stuff in notification theme to make it look more like default notifications in dark theme

Plugins.md:
• Adds defDarkColors to plugins list

-JS